### PR TITLE
add helper to index exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ module.exports = {
         AfterSuite: false,
         within: false,
         Data: false,
-        DataTable: false
+        DataTable: false,
+        Helper: false
       },
     }
   },


### PR DESCRIPTION
I have a problems with eslint while using your plugin, it doesn't see helper class when I extends form it to make my own helper hooks before/after tests. This small fix resolves this issue for me.