### PR TITLE
docs(readme): fix typo in rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then configure the rules you want to use under the rules section.
 ```
 {
   "rules": {
-    "coedeceptjs/no-actor-in-scenario": 2
+    "codeceptjs/no-actor-in-scenario": 2
   }
 }
 ```


### PR DESCRIPTION
Fixes typo in rule documentation