### PR TITLE
New rule: no-exclusive-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 - `no-actor-in-scenario`: Prevents the use of the `actor` in a `Scenario` and delegate to page objects
+- `no-exclusive-tests`: Prevents the use of `Scenario.only` to focus tests
 - `no-skipped-tests`: Prevents the use of `xScenario` or `Scenario.skip` to [skip tests][1]
 
   [1]: https://codecept.io/basics/#skipping

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   rules: {
     "no-actor-in-scenario": require("./lib/rules/no-actor-in-scenario"),
+    "no-exclusive-tests": require("./lib/rules/no-exclusive-tests"),
     "no-skipped-tests": require("./lib/rules/no-skipped-tests")
   }
 };

--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -1,0 +1,39 @@
+'use strict';
+
+function isOnlyMethodCall(callee) {
+  return callee.type === 'MemberExpression' &&
+      callee.object.name === 'Scenario' &&
+      callee.property.name === 'only';
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: '',
+      category: 'Best Practices',
+      recommended: true
+    },
+    fixable: 'code',
+    messages: {
+      exclusiveTest: 'Unexpected exclusive test'
+    },
+    schema: []
+  },
+  create: function (context) {
+    return {
+      CallExpression: function (node) {
+        if (isOnlyMethodCall(node.callee)) {
+          context.report({
+            node: node,
+            messageId: 'exclusiveTest',
+            fix: function (fixer) {
+              var start = node.callee.object.range[1];
+              var end = node.callee.range[1];
+              return fixer.removeRange([start, end])
+            }
+          });
+        }
+      }
+    };
+  },
+};

--- a/tests/lib/rules/no-exclusive-tests.js
+++ b/tests/lib/rules/no-exclusive-tests.js
@@ -12,7 +12,8 @@ function invalidScenario (code) {
     parserOptions: { ecmaVersion: 6 },
     errors: [
       { message: 'Unexpected exclusive test' }
-    ]
+    ],
+    output: 'Scenario("this is not", function () {});'
   };
 }
 

--- a/tests/lib/rules/no-exclusive-tests.js
+++ b/tests/lib/rules/no-exclusive-tests.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var RuleTester = require('eslint').RuleTester;
+
+var rule = require('../../../lib/rules/no-exclusive-tests');
+
+var ruleTester = new RuleTester();
+
+function invalidScenario (code) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6 },
+    errors: [
+      { message: 'Unexpected exclusive test' }
+    ]
+  };
+}
+
+ruleTester.run('no-exclusive-tests', rule, {
+  valid: [
+    'Scenario("this is cool", function () {});'
+  ],
+  invalid: [
+    invalidScenario('Scenario.only("this is not", function () {});')
+  ],
+});


### PR DESCRIPTION
Name and report based on the Mocha ESLint plugin's [`no-exclusive-tests` rule][1].

Can detect and fix `Scenario.only`.

  [1]: https://github.com/lo1tuma/eslint-plugin-mocha/blob/d36c1499133ab688bd81a650e19f0d0cd11ea248/docs/rules/no-exclusive-tests.md