### PR TITLE
No pause rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Then configure the rules you want to use under the rules section.
 | `no-exclusive-tests` | Prevents the use of `Scenario.only` to focus tests | ![error] | ![fixable] |
 | `no-skipped-tests` | Prevents the use of `xScenario` or `Scenario.skip` to [skip tests][1] | ![error] | ![fixable] |
 | `no-pause-in-scenario` | Prevents the use of `pause()` in a test | | ![fixable] |
+
   [1]: https://codecept.io/basics/#skipping
 
   [fixable]: https://img.shields.io/badge/-fixable-green.svg

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Then configure the rules you want to use under the rules section.
 | `no-actor-in-scenario` | Prevents the use of the `actor` in a `Scenario` and delegate to page objects | | |
 | `no-exclusive-tests` | Prevents the use of `Scenario.only` to focus tests | ![error] | ![fixable] |
 | `no-skipped-tests` | Prevents the use of `xScenario` or `Scenario.skip` to [skip tests][1] | ![error] | ![fixable] |
-| `no-pause-in-scenario` | Prevents the use of `pause()` in a test | | ![fixable] |
+| `no-pause-in-scenario` | Prevents the use of `pause()` in a test | ![error] | ![fixable] |
 
   [1]: https://codecept.io/basics/#skipping
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Then configure the rules you want to use under the rules section.
 | `no-actor-in-scenario` | Prevents the use of the `actor` in a `Scenario` and delegate to page objects | | |
 | `no-exclusive-tests` | Prevents the use of `Scenario.only` to focus tests | ![error] | ![fixable] |
 | `no-skipped-tests` | Prevents the use of `xScenario` or `Scenario.skip` to [skip tests][1] | ![error] | ![fixable] |
-
+| `no-pause-in-scenario` | Prevents the use of `pause()` in a test | | ![fixable] |
   [1]: https://codecept.io/basics/#skipping
 
   [fixable]: https://img.shields.io/badge/-fixable-green.svg

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = {
       rules: {
         "codeceptjs/no-actor-in-scenario": "off",
         "codeceptjs/no-exclusive-tests": "error",
-        "codeceptjs/no-skipped-tests": "error"
+        "codeceptjs/no-skipped-tests": "error",
+        "codeceptjs/no-pause-in-scenario": "error"
       }
     }
   },
@@ -45,6 +46,7 @@ module.exports = {
   rules: {
     "no-actor-in-scenario": require("./lib/rules/no-actor-in-scenario"),
     "no-exclusive-tests": require("./lib/rules/no-exclusive-tests"),
-    "no-skipped-tests": require("./lib/rules/no-skipped-tests")
+    "no-skipped-tests": require("./lib/rules/no-skipped-tests"),
+    "no-pause-in-scenario": require("./lib/rules/no-pause-in-scenario")
   }
 };

--- a/lib/rules/no-pause-in-scenario.js
+++ b/lib/rules/no-pause-in-scenario.js
@@ -23,7 +23,12 @@ module.exports = {
         if (isPauseCalled(node.callee)) {
           context.report({
             node: node,
-            messageId: 'pausedTest'
+            messageId: 'pausedTest',
+            fix: function (fixer) {
+              var start = node.callee.range[0];
+              var end = node.callee.range[1] + 2;
+              return fixer.removeRange([start, end])
+            }
           });
         }
       }

--- a/lib/rules/no-pause-in-scenario.js
+++ b/lib/rules/no-pause-in-scenario.js
@@ -1,0 +1,32 @@
+'use strict';
+
+function isPauseCalled(callee){
+  return callee.type === 'Identifier' && callee.name === 'pause'; 
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: '',
+      category: 'Best Practices',
+      recommended: true
+    },
+    fixable: 'code',
+    messages: {
+      pausedTest: 'Unexpected pause in test'
+    },
+    schema: []
+  },
+  create: function (context) {
+    return {
+      CallExpression: function (node) {
+        if (isPauseCalled(node.callee)) {
+          context.report({
+            node: node,
+            messageId: 'pausedTest'
+          });
+        }
+      }
+    };
+  },
+}

--- a/tests/lib/rules/no-pause-in-scenario.js
+++ b/tests/lib/rules/no-pause-in-scenario.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var RuleTester = require('eslint').RuleTester;
+
+var rule = require('../../../lib/rules/no-pause-in-scenario');
+
+var ruleTester = new RuleTester();
+
+function invalidScenario(input, output) {
+  return {
+    code: input,
+    parserOptions: { ecmaVersion: 6 },
+    errors: [
+      { message: 'Unexpected pause in test' }
+    ],
+    output: output
+  };
+}
+
+ruleTester.run('no-pause-in-scenario', rule, {
+  valid: [
+    'Scenario("this is cool", function () {});'
+  ],
+  invalid: [
+    invalidScenario(
+        'Scenario("this is not", function () {pause()});',
+	'Scenario("this is not", function () {pause()});'
+    ),
+    invalidScenario(
+        'Scenario("nor is this", function () {pause()});',
+	'Scenario("nor is this", function () {pause()});'
+    )
+  ],
+});

--- a/tests/lib/rules/no-pause-in-scenario.js
+++ b/tests/lib/rules/no-pause-in-scenario.js
@@ -24,11 +24,11 @@ ruleTester.run('no-pause-in-scenario', rule, {
   invalid: [
     invalidScenario(
         'Scenario("this is not", function () {pause()});',
-	'Scenario("this is not", function () {pause()});'
+	'Scenario("this is not", function () {});'
     ),
     invalidScenario(
         'Scenario("nor is this", function () {pause()});',
-	'Scenario("nor is this", function () {pause()});'
+	'Scenario("nor is this", function () {});'
     )
   ],
 });


### PR DESCRIPTION
I have added a rule to detect and fix instances of a pause() in a test. This is to prevent rogue pauses ending up in CI/CD pipelines and causing tests to hang indefinitely/for a long time